### PR TITLE
For configuring activator url at runtime 

### DIFF
--- a/application/src/main/java/org/kgrid/library/LibraryApplication.java
+++ b/application/src/main/java/org/kgrid/library/LibraryApplication.java
@@ -15,8 +15,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @SpringBootApplication(scanBasePackages = {"org.kgrid.library","org.kgrid.shelf"})
 public class LibraryApplication implements WebMvcConfigurer {
 
-    public LibraryApplication(@Value("${library.name}") String name) {
+    public LibraryApplication(@Value("${library.name}") String name,@Value("${kgrid.activator.url}") String activatorUrl
+                              ) {
         this.name = name;
+        this.activatorUrl = activatorUrl;
     }
 
     public static void main(String[] args) {
@@ -34,7 +36,14 @@ public class LibraryApplication implements WebMvcConfigurer {
         return new SimpleInfoContributor("library.name", name);
     }
 
+    @Bean
+    SimpleInfoContributor getActivatorUrlContributor()  {
+        return new SimpleInfoContributor("kgrid.activator.url", activatorUrl);
+    }
+    
     private String name;
+
+    private String activatorUrl;
 
     public String getLibraryName() {
         return name;

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 library.name=MichiganLibrary(Dev)
+kgrid.activator.url=http://localhost:8080
 
 ### SPRING BOOT CONFIG ###
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -139,9 +139,11 @@ export default {
     var self = this
     Promise.all([
       this.$http.get("./static/json/metadataschema.json"),
-      this.$http.get("./static/json/config.json")
+      this.$http.get("./static/json/config.json"),
+      this.$http.get("/info")
     ]).then(function (responses) {
-      let activatorUrlList = process.env.VUE_APP_KGRID_ACTIVATOR_URLS;
+      console.log(responses[2].data);
+      let activatorUrlList = responses[2].data["kgrid.activator.url"];
       console.log("Env Var - VUE_APP_KGRID_ACTIVATOR_URLS: "+ activatorUrlList);
       let activatorUrls = activatorUrlList ? activatorUrlList.split(";") :
         ["http://localhost:8080", "https://kgrid-activator.herokuapp.com"];

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -155,6 +155,7 @@ export default {
       })
       self.$store.commit('setactivatorurls', storedUrls)
       self.$store.commit('setmetaschema', responses[0].data);
+      self.$store.commit('setlibraryinfo', responses[2].data);
       self.$store.commit('setdemourl', responses[1].data.demourl);
       self.serverSelection = responses[1].data.serverSelection
       self.$store.commit('setservers', self.servers);

--- a/client/src/components/objact.vue
+++ b/client/src/components/objact.vue
@@ -172,6 +172,8 @@ export default {
   },
   watch: {
     activatorurlselect() {
+      // Need to check with the activator for the shelf endpoint
+
       var self = this
       this.$http.get(this.activatorurlselect + '/kos')
         .then(() => {

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -42,7 +42,8 @@ export default new Vuex.Store({
     currentServerIndex: 2,
     hasError: false,
     errorMessage: '',
-    demourl: 'https://editor.swagger.io'
+    demourl: 'https://editor.swagger.io',
+    libraryInfo:{}
   },
   getters: {
     getobjectlist: state => state.kolist,
@@ -95,9 +96,15 @@ export default new Vuex.Store({
         url = url + '/'
       }
       return url
+    },
+    getLibraryInfo: state=>{
+      return state.libraryInfo
     }
   },
   mutations: {
+    setlibraryinfo(state, info){
+      state.libraryInfo = info;
+    },
     setmetaschema(state, schema) {
       state.metaschema = schema;
     },


### PR DESCRIPTION
[#176076759] Add kgrid.activator.url to /info; Vue app sync the activator url with the `/info` object from the library back end.